### PR TITLE
Implemented fix for crash on unexpected QR code format

### DIFF
--- a/Tofu/Account.swift
+++ b/Tofu/Account.swift
@@ -47,7 +47,8 @@ class Account {
             default: break
             }
         }
-        if password.secret.count == 0 { return nil }
+        
+        if password.secret.count == 0 || ![6, 8].contains(password.digits) { return nil }
     }
 
     var description: String {

--- a/Tofu/AccountCreationDelegate.swift
+++ b/Tofu/AccountCreationDelegate.swift
@@ -1,3 +1,4 @@
 protocol AccountCreationDelegate: class {
     func createAccount(_ account: Account)
+    func rejectAccount()
 }

--- a/Tofu/AccountsViewController.swift
+++ b/Tofu/AccountsViewController.swift
@@ -160,7 +160,7 @@ class AccountsViewController: UITableViewController, UIImagePickerControllerDele
             let qrCodeURL = URL(string: messageString),
             let account = Account(url: qrCodeURL) else {
                 let noQRAlert = UIAlertController(title: "Error",
-                                                  message: "Failed to detect QR code in the provided image.",
+                                                  message: "Failed to detect valid QR code in the provided image.",
                                                   preferredStyle: .alert)
                 noQRAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                 self.present(noQRAlert, animated: true, completion: nil)
@@ -322,6 +322,15 @@ extension AccountsViewController: AccountCreationDelegate {
         let indexPaths = [IndexPath(row: lastRow, section: 0)]
         tableView.insertRows(at: indexPaths, with: .automatic)
         updateEditing()
+    }
+    
+    func rejectAccount() {
+        let alert = UIAlertController(
+            title: "Unable to Add Account",
+            message: "The account information was not of the expected format.",
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        self.present(alert, animated: true)
     }
 }
 

--- a/Tofu/ScanningViewController.swift
+++ b/Tofu/ScanningViewController.swift
@@ -72,7 +72,14 @@ AVCaptureMetadataOutputObjectsDelegate {
         guard metadataObjects.count > 0,
             let metadataObject = metadataObjects.first as? AVMetadataMachineReadableCodeObject, metadataObject.type == AVMetadataObject.ObjectType.qr,
             let url = URL(string: metadataObject.stringValue!),
-            let account = Account(url: url) else { return }
+            let account = Account(url: url) else {
+                presentingViewController?.dismiss(animated: true) {
+                    OperationQueue.main.addOperation {
+                        self.delegate?.rejectAccount()
+                    }
+                }
+                return
+            }
         output.setMetadataObjectsDelegate(nil, queue: nil)
         delegate?.createAccount(account)
         presentingViewController?.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
Hey again @calleerlandsson. Just noticed #40 and decided to take a quick stab at a fix for it. This seems to work for me -- the main changes are:

- Added enforcement of 6/8 digit code length
- Added rejection method (with error message) for attempts to add accounts that don't adhere to the current expected format

Let me know if there are any modifications needed! 